### PR TITLE
N0.14 アカウント作成画面の実装

### DIFF
--- a/front/app/sign-up/page.tsx
+++ b/front/app/sign-up/page.tsx
@@ -1,0 +1,9 @@
+import { SignUpForm } from "@/features/auth/components/SignUpForm";
+
+export default async function Page() {
+  return (
+    <>
+        <SignUpForm />
+    </>
+  );
+}

--- a/front/components/Header.tsx
+++ b/front/components/Header.tsx
@@ -27,7 +27,9 @@ export const Header = () => {
         >
           ログイン
         </button>
-        <button className="w-[118px] h-[32px] bg-[#69BEEF] text-white text-[12px] font-bold leading-[15px] tracking-[0.21666669845581055px] text-center rounded-[16px] flex items-center justify-center">
+        <button 
+          onClick={() => router.push("/sign-up")}
+          className="w-[118px] h-[32px] bg-[#69BEEF] text-white text-[12px] font-bold leading-[15px] tracking-[0.21666669845581055px] text-center rounded-[16px] flex items-center justify-center">
           新規登録
         </button>
       </div>

--- a/front/features/auth/components/SignInForm.tsx
+++ b/front/features/auth/components/SignInForm.tsx
@@ -48,13 +48,12 @@ export const SignInForm = () => {
         </div>
         <div className="flex-1 flex items-center justify-center">
           <div className="max-w-md p-8">
-            <h1 className="text-[40px] font-bold leading-[40px] tracking-[0.21666669845581055px] text-center font-['October_Devanagari'] mb-2">
+            <h1 style={{ fontSize: "40px" }} className="font-bold leading-[40px] tracking-[0.21666669845581055px] text-center font-['October_Devanagari'] mb-2">
               おかえりなさい！
             </h1>
-            <p className="text-[14px] font-bold leading-[14px] tracking-[0.21666669845581055px] text-center font-['October_Devanagari'] mb-8">
+            <p style={{ fontSize: "14px" }} className="font-bold leading-[14px] tracking-[0.21666669845581055px] text-center font-['October_Devanagari'] mb-8">
               今日も素敵な写真をいっぱい投稿しましょう
             </p>
-            <h2 className="text-2xl font-bold mb-6 text-center">ログイン</h2>
             <div className="flex flex-col gap-6 w-[260px] mx-auto">
               <TextField
                 fullWidth
@@ -62,6 +61,7 @@ export const SignInForm = () => {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 variant="outlined"
+                style={{ marginTop: "48px" }}
                 InputLabelProps={{
                   shrink: true,
                   sx: {
@@ -88,6 +88,7 @@ export const SignInForm = () => {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 variant="outlined"
+                style={{ marginTop: "16px" }}
                 InputLabelProps={{
                   shrink: true,
                   sx: {
@@ -111,19 +112,20 @@ export const SignInForm = () => {
                 onClick={handleSignIn}
                 style={{
                   height: "56px",
+                  marginTop: "32px"
                 }}
                 className="bg-[#69BEEF] text-white rounded-md hover:bg-[#5CAADB]"
               >
                 ログイン
               </button>
-              <p className="font-['October_Devanagari'] text-[10px] font-[400] leading-[16px] text-center">
+              <p style={{ marginTop: "16px" }} className="font-['October_Devanagari'] text-[10px] font-[400] leading-[16px] text-center">
                 アカウントをお持ちではありませんか？{" "}
-                <Link href="/register" className="underline">
+                <Link href="/sign-up" className="underline">
                   アカウント作成
                 </Link>
               </p>
-              <p className="text-center text-[#000000] mt-[30px]">
-                -------------------または-------------------
+              <p style={{ marginTop: "48px" }} className="text-center text-[#000000] mt-[30px]">
+                ---------------------------または---------------------------
               </p>
               <button
                 style={{
@@ -132,6 +134,7 @@ export const SignInForm = () => {
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
+                  marginTop: "16px" 
                 }}
                 className="text-[#000000] rounded-md hover:bg-gray-200"
               >

--- a/front/features/auth/components/SignUpForm.tsx
+++ b/front/features/auth/components/SignUpForm.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { createUserWithEmailAndPassword } from "firebase/auth";
+import Image from "next/image";
+import { Link, TextField } from "@mui/material";
+import { auth } from "@/libs/firebase/client";
+
+export const SignUpForm = () => {
+  const [email, setEmail] = useState("");
+
+  const handleSignUp = async () => {
+    try {
+      const password = Math.random().toString(8).slice(2, 10);
+      const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+      window.location.href = "/";
+      console.log(userCredential);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex">
+        <div className="flex-1 flex items-center justify-center">
+          <div className="max-w-md p-8">
+            <h1
+              style={{ fontSize: "40px" }}
+              className="font-bold leading-[40px] tracking-[0.21666669845581055px] text-center font-['October_Devanagari'] mb-2"
+            >
+              アカウントの作成
+            </h1>
+
+            <div className="flex flex-col gap-6 w-[260px] mx-auto">
+              <TextField
+                fullWidth
+                label="メールアドレス*"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                variant="outlined"
+                style={{ marginTop: "48px" }}
+                InputLabelProps={{
+                  shrink: true,
+                  sx: {
+                    color: "#69BEEF",
+                  },
+                }}
+                sx={{
+                  height: "64px",
+                  "& .MuiInputLabel-shrink": {
+                    transform: "translate(14px, -9px) scale(0.75)",
+                  },
+                  "& .MuiOutlinedInput-root": {
+                    "& fieldset": {
+                      borderWidth: "2px",
+                      borderColor: "#69BEEF",
+                    },
+                  },
+                }}
+              />
+              {/* <TextField
+                fullWidth
+                type="password"
+                label="パスワード"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                variant="outlined"
+                style={{ marginTop: "16px" }}
+                InputLabelProps={{
+                  shrink: true,
+                  sx: {
+                    color: "#69BEEF",
+                  },
+                }}
+                sx={{
+                  height: "64px",
+                  "& .MuiInputLabel-shrink": {
+                    transform: "translate(14px, -9px) scale(0.75)",
+                  },
+                  "& .MuiOutlinedInput-root": {
+                    "& fieldset": {
+                      borderWidth: "2px",
+                      borderColor: "#69BEEF",
+                    },
+                  },
+                }}
+              /> */}
+              <button
+                onClick={handleSignUp}
+                style={{
+                  height: "56px",
+                  marginTop: "32px",
+                }}
+                className="bg-[#69BEEF] text-white rounded-md hover:bg-[#5CAADB]"
+              >
+                作成する
+              </button>
+              <p
+                style={{ marginTop: "16px" }}
+                className="font-['October_Devanagari'] text-[10px] font-[400] leading-[16px] text-center"
+              >
+                既にアカウントをお持ちですか？{" "}
+                <Link href="/sign-in" className="underline">
+                  ログイン
+                </Link>
+              </p>
+              <p style={{ marginTop: "48px" }} className="text-center text-[#000000] mt-[30px]">
+                ---------------------------または---------------------------
+              </p>
+              <button
+                style={{
+                  border: "1px solid #B2B2B2",
+                  height: "56px",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  marginTop: "16px",
+                }}
+                className="text-[#000000] rounded-md hover:bg-gray-200"
+              >
+                <Image src="/google-icon.png" alt="Google Icon" width={24} height={24} />
+                <p style={{ marginLeft: "5px" }}>Googleで続行</p>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div className="flex-1 relative h-full">
+          <Image
+            src="/signup-icon.png"
+            alt="Login page image"
+            className="object-cover w-full h-full"
+            width={864}
+            height={800}
+          />
+        </div>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
### 概要
アカウント作成画面の実装

### 実装
- signup用のpage作成
- ロゴ画像の設置
- signup用のディレクトリのpage作成

### 画像
![スクリーンショット 2025-02-03 0 36 28](https://github.com/user-attachments/assets/28269917-5dfd-40f9-a671-5037ad4a2f66)
