### PR TITLE
Topページの修正

### DIFF
--- a/nextjs/components/post-card.tsx
+++ b/nextjs/components/post-card.tsx
@@ -34,20 +34,16 @@ export const PostCard = ({
     userName,
     userImageUrl,
     isLiked,
-    setIsLiked,
     handleLikeOrUnlike,
   } = postCardProps;
 
   const handleForwardToPostDetail = (postId: string | bigint) => {
-    console.log(postId);
-    const postIdString =
-      typeof postId === "bigint" ? postId.toString() : postId;
+    const postIdString = typeof postId === "bigint" ? postId.toString() : postId;
     router.push(`/posts/${postIdString}`);
   };
 
   const handleForwardToUserDetail = (userId: string | bigint) => {
-    const userIdString =
-      typeof userId === "bigint" ? userId.toString() : userId;
+    const userIdString = typeof userId === "bigint" ? userId.toString() : userId;
     router.push(`/users/${userIdString}`);
   };
 
@@ -61,49 +57,28 @@ export const PostCard = ({
         className={styles.likesPostsItemImage}
         onClick={() => handleForwardToPostDetail(postId)}
       />
-      <div className={styles.likesPostsItemImageContents}>
-        <MdOutlinePhoto className={styles.MdOutlinePhoto} />
-        <p className={styles.likesPostsItemImageContentsText}>
-          {postImageCount ?? 0}
-        </p>
-      </div>
+      {postImageCount > 1 && (
+        <div className={styles.likesPostsItemImageContents}>
+          <MdOutlinePhoto className={styles.MdOutlinePhoto} />
+          <p className={styles.likesPostsItemImageContentsText}>{postImageCount}</p>
+        </div>
+      )}
       <div className={styles.userInfoLikeContainer}>
         <div className={styles.userInfo}>
           <p className={styles.userInfoTitle}>{postName}</p>
           <div className={styles.userInfoContainer}>
-            <Image
-              src={userImageUrl}
-              alt="new-post-image"
-              className={styles.userInfoIcon}
-              fill
-            />
-            <p
-              className={styles.userInfoName}
-              onClick={() => handleForwardToUserDetail(userId)}
-            >
+            <Image src={userImageUrl} alt="new-post-image" className={styles.userInfoIcon} fill />
+            <p className={styles.userInfoName} onClick={() => handleForwardToUserDetail(userId)}>
               {userName}
             </p>
           </div>
         </div>
         <div className={styles.likesPostsItemLikeContents}>
-          <div
-            className={styles.likesPostsItemLikeItem}
-            onClick={() => handleLikeOrUnlike()}
-          >
+          <div className={styles.likesPostsItemLikeItem} onClick={() => handleLikeOrUnlike()}>
             {isLiked ? (
-              <Image
-                src="/heart-outline.png"
-                alt="heart"
-                className={styles.likesIcon}
-                fill
-              />
+              <Image src="/heart-outline.png" alt="heart" className={styles.likesIcon} fill />
             ) : (
-              <Image
-                src="/heart.png"
-                alt="heart"
-                className={styles.likesIcon}
-                fill
-              />
+              <Image src="/heart.png" alt="heart" className={styles.likesIcon} fill />
             )}
           </div>
         </div>

--- a/nextjs/features/home/components/popular-post-list.tsx
+++ b/nextjs/features/home/components/popular-post-list.tsx
@@ -16,15 +16,8 @@ export const PopularPostList = ({
   setIsLiked: React.Dispatch<React.SetStateAction<boolean>>;
   setPopularPostList: React.Dispatch<React.SetStateAction<PopularPost[]>>;
 }) => {
-  const [likedPosts, setLikedPosts] = useState<{ [postId: string]: boolean }>(
-    {}
-  );
-  // const [chunkedPosts, setChunkedPosts] = useState<PopularPost[][]>([]);
+  const [likedPosts, setLikedPosts] = useState<{ [postId: string]: boolean }>({});
   const { handleLikeOrUnlike } = useLikePost();
-
-  const chunkPopularPostList = (postList: PopularPost[]) => {
-    return _.chunk(postList, 4);
-  };
 
   const handleLike = async (postId: string) => {
     const currentLiked = likedPosts[postId];
@@ -34,9 +27,7 @@ export const PopularPostList = ({
     setLikedPosts((prev) => ({ ...prev, [postId]: !currentLiked }));
 
     setPopularPostList((prevList) =>
-      prevList.map((post) =>
-        post.id === postId ? { ...post, is_liked: !currentLiked } : post
-      )
+      prevList.map((post) => (post.id === postId ? { ...post, is_liked: !currentLiked } : post))
     );
   };
 
@@ -61,7 +52,7 @@ export const PopularPostList = ({
                 postId: post.id,
                 userId: post.user.id,
                 postName: post.title,
-                postImageUrl: "/pickup-image.png",
+                postImageUrl: post.images[0].url,
                 postImageCount: post.images.length,
                 userName: post.user.name,
                 userImageUrl: "/posts/sample-user-icon.png",


### PR DESCRIPTION
Topページにて、以下を修正

- 投稿画像が１枚以下の場合、画像の枚数を表示させない
- 人気画像を投稿画像から取得できるように修正