### PR TITLE
新規登録画面の改修

### DIFF
--- a/nextjs/features/auth/components/sign-up-form.tsx
+++ b/nextjs/features/auth/components/sign-up-form.tsx
@@ -28,7 +28,7 @@ export const SignUpForm = ({
       return false;
     }
 
-    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+    const emailRegex = /^[a-zA-Z0-9._%+-]+@[^@.]+\.[^@]+$/;
     if (!emailRegex.test(email)) {
       setErrorMail("正しいメールアドレスを入力してください");
       return false;

--- a/nextjs/features/auth/components/sign-up-form.tsx
+++ b/nextjs/features/auth/components/sign-up-form.tsx
@@ -27,6 +27,12 @@ export const SignUpForm = ({
       setErrorMail("メールアドレスを入力してください");
       return false;
     }
+
+    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+    if (!emailRegex.test(email)) {
+      setErrorMail("正しいメールアドレスを入力してください");
+      return false;
+    }
     setErrorMail("");
     return true;
   };
@@ -39,6 +45,16 @@ export const SignUpForm = ({
 
     if (password.length < 6) {
       setErrorPassword("パスワードは6文字以上で入力してください");
+      return false;
+    }
+
+    // 半角英字、数字、記号をすべて含むかチェック
+    const hasLetter = /[a-zA-Z]/.test(password);
+    const hasNumber = /[0-9]/.test(password);
+    const hasSymbol = /[!@#$%^&*()_+{}\[\]:;<>,.?~\\/-]/.test(password);
+
+    if (!(hasLetter && hasNumber && hasSymbol)) {
+      setErrorPassword("パスワードは半角英字、数字、記号を含めてください");
       return false;
     }
 
@@ -101,9 +117,7 @@ export const SignUpForm = ({
                   },
                 }}
               />
-              {errorMail && (
-                <p className={styles.errorMailMessage}>{errorMail}</p>
-              )}
+              {errorMail && <p className={styles.errorMailMessage}>{errorMail}</p>}
             </div>
 
             <div className={styles.textForm}>
@@ -136,9 +150,7 @@ export const SignUpForm = ({
               <p className={styles.warningLabel}>
                 パスワードは半角英字、数字、記号を合わせた6文字以上で入力してください
               </p>
-              {errorPassword && (
-                <p className={styles.errorPasswordMessage}>{errorPassword}</p>
-              )}
+              {errorPassword && <p className={styles.errorPasswordMessage}>{errorPassword}</p>}
             </div>
             <div className={styles.createButtonContainer}>
               <button onClick={handleSignUp} className={styles.createButton}>
@@ -148,7 +160,7 @@ export const SignUpForm = ({
             <div className={styles.separateLoginContainer}>
               <p className={styles.separateLoginText}>
                 既にアカウントをお持ちですか？{" "}
-                <Link href="/sign-in" className="underline">
+                <Link href="/signin" className="underline">
                   ログイン
                 </Link>
               </p>
@@ -173,12 +185,7 @@ export const SignUpForm = ({
 
             <div className={styles.googleLoginContainer}>
               <button className={styles.googleLoginButton}>
-                <Image
-                  src="/google-icon.png"
-                  alt="Google Icon"
-                  width={24}
-                  height={24}
-                />
+                <Image src="/google-icon.png" alt="Google Icon" width={24} height={24} />
                 <p className={styles.googleLoginText}>Googleで続行</p>
               </button>
             </div>

--- a/nextjs/features/users/components/account-info-input.tsx
+++ b/nextjs/features/users/components/account-info-input.tsx
@@ -7,6 +7,7 @@ import { createUser } from "../endpoint";
 import { useRouter } from "next/navigation";
 import { ClipLoader } from "react-spinners";
 import { useSession } from "next-auth/react";
+import { createYears, createMonths, createDays } from "@/utils/date";
 
 export const AccountInfoInput = ({
   email,
@@ -18,9 +19,6 @@ export const AccountInfoInput = ({
   setIsSignUp: (isSignUp: boolean) => void;
 }) => {
   const router = useRouter();
-  const years = Array.from({ length: 100 }, (_, index) => 2025 - index); // 2025年から遡る
-  const months = Array.from({ length: 12 }, (_, index) => index + 1); // 1月から12月
-  const days = Array.from({ length: 31 }, (_, index) => index + 1);
   const sexOptions = [
     { label: "男", value: "male" },
     { label: "女", value: "female" },
@@ -85,12 +83,7 @@ export const AccountInfoInput = ({
 
   const handleCreateAccount = async () => {
     try {
-      if (
-        !isValidNickName() ||
-        !isValidBirthday() ||
-        !isValidSex() ||
-        !isValidTerms()
-      ) {
+      if (!isValidNickName() || !isValidBirthday() || !isValidSex() || !isValidTerms()) {
         return;
       }
 
@@ -134,21 +127,14 @@ export const AccountInfoInput = ({
                       onChange={(e) => setName(e.target.value)}
                     />
                   </div>
-                  <p className={styles.warningLabel}>
-                    あなたの名前として表示されます
-                  </p>
-                  {errorName && (
-                    <p className={styles.errorNameMessage}>{errorName}</p>
-                  )}
+                  <p className={styles.warningLabel}>あなたの名前として表示されます</p>
+                  {errorName && <p className={styles.errorNameMessage}>{errorName}</p>}
                 </div>
                 <div className={styles.genderContainer}>
                   <p className={styles.genderLabel}>性別</p>
                   <div className={styles.genderSelectSection}>
                     {sexOptions.map((option) => (
-                      <label
-                        key={option.value}
-                        className={styles.genderSelectLabel}
-                      >
+                      <label key={option.value} className={styles.genderSelectLabel}>
                         <input
                           type="radio"
                           name="gender"
@@ -162,9 +148,7 @@ export const AccountInfoInput = ({
                     ))}
                   </div>
 
-                  {errorSex && (
-                    <p className={styles.errorSexMessage}>{errorSex}</p>
-                  )}
+                  {errorSex && <p className={styles.errorSexMessage}>{errorSex}</p>}
                 </div>
                 <div className={styles.birthdayContainer}>
                   <p className={styles.birthdayLabel}>生年月日</p>
@@ -174,10 +158,10 @@ export const AccountInfoInput = ({
                         id="year"
                         className={styles.birthdaySelect}
                         value={year}
-                        onChange={(e) => setYear(e.target.value)}
+                        onChange={(e) => setYear(Number(e.target.value))}
                       >
                         <option value="">年</option>
-                        {years.map((y) => (
+                        {createYears().map((y) => (
                           <option key={y} value={y}>
                             {y}
                           </option>
@@ -189,10 +173,10 @@ export const AccountInfoInput = ({
                         id="month"
                         className={styles.birthdaySelect}
                         value={month}
-                        onChange={(e) => setMonth(e.target.value)}
+                        onChange={(e) => setMonth(Number(e.target.value))}
                       >
                         <option value="">月</option>
-                        {months.map((m) => (
+                        {createMonths().map((m) => (
                           <option key={m} value={m}>
                             {m}
                           </option>
@@ -207,16 +191,14 @@ export const AccountInfoInput = ({
                         onChange={(e) => setDay(e.target.value)}
                       >
                         <option value="">日</option>
-                        {days.map((d) => (
+                        {createDays(year, month).map((d) => (
                           <option key={d} value={d}>
                             {d}
                           </option>
                         ))}
                       </select>
                       {errorBirthday && (
-                        <p className={styles.errorBirthdayMessage}>
-                          {errorBirthday}
-                        </p>
+                        <p className={styles.errorBirthdayMessage}>{errorBirthday}</p>
                       )}
                     </div>
                   </div>
@@ -230,33 +212,20 @@ export const AccountInfoInput = ({
                       onChange={(e) => setTermsChecked(e.target.checked)}
                     />
                     <span>
-                      <a
-                        href="/terms"
-                        target="_blank"
-                        className={styles.linkText}
-                      >
+                      <a href="/terms" target="_blank" className={styles.linkText}>
                         利用規約
                       </a>{" "}
                       と
-                      <a
-                        href="/privacy"
-                        target="_blank"
-                        className={styles.linkText}
-                      >
+                      <a href="/privacy" target="_blank" className={styles.linkText}>
                         プライバシーポリシー
                       </a>{" "}
                       に同意する
                     </span>
                   </label>
-                  {errorTerms && (
-                    <p className={styles.errorTermsMessage}>{errorTerms}</p>
-                  )}
+                  {errorTerms && <p className={styles.errorTermsMessage}>{errorTerms}</p>}
                 </div>
                 <div className={styles.signupContent}>
-                  <button
-                    onClick={handleCreateAccount}
-                    className={styles.userCreateButton}
-                  >
+                  <button onClick={handleCreateAccount} className={styles.userCreateButton}>
                     アカウント作成
                   </button>
                 </div>

--- a/nextjs/features/users/components/account-info-input.tsx
+++ b/nextjs/features/users/components/account-info-input.tsx
@@ -53,7 +53,7 @@ export const AccountInfoInput = ({
   const isValidBirthday = () => {
     setErrorBirthday("");
     if (year === "" || month === "" || day === "") {
-      setErrorBirthday("誕生日を選択してください");
+      setErrorBirthday("生年月日を選択してください");
       return false;
     }
     return true;
@@ -167,7 +167,7 @@ export const AccountInfoInput = ({
                   )}
                 </div>
                 <div className={styles.birthdayContainer}>
-                  <p className={styles.birthdayLabel}>誕生日</p>
+                  <p className={styles.birthdayLabel}>生年月日</p>
                   <div className={styles.birthdayContent}>
                     <div className={styles.birthdaySelectContent}>
                       <select

--- a/nextjs/prisma/schema.prisma
+++ b/nextjs/prisma/schema.prisma
@@ -97,7 +97,7 @@ model users {
   id                  String               @id @default(uuid())
   uid                 String               @unique @db.VarChar(255)
   name                String               @db.VarChar(50)
-  email               String               @db.VarChar(30)
+  email               String               @db.VarChar(255)
   introduction_title  String?              @db.VarChar(255)
   introduction_detail String?              @db.Text
   gender              genders

--- a/nextjs/utils/date.ts
+++ b/nextjs/utils/date.ts
@@ -4,3 +4,28 @@ export const getStartOfWeek = () => {
   startOfWeek.setHours(0, 0, 0, 0);  // 時刻を0時に設定
   return startOfWeek;
 };
+
+export const createYears = () => {
+  const currentYear = new Date().getFullYear();
+  return Array.from({ length: currentYear - 1900 + 1 }, (_, index) => currentYear - index);
+};
+
+export const createMonths = () => {
+  return Array.from({ length: 12 }, (_, index) => index + 1);
+};
+
+export const createDays = (year: number, month: number) => {
+  let daysInMonth;
+    
+  if (month === 2) {
+    // うるう年判定（4で割り切れる && 100で割り切れない or 400で割り切れる）
+    const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+    daysInMonth = isLeapYear ? 29 : 28;
+  } else if ([4, 6, 9, 11].includes(month)) {
+    daysInMonth = 30;
+  } else {
+    daysInMonth = 31;
+  }
+
+  return Array.from({ length: daysInMonth }, (_, index) => index + 1);
+};


### PR DESCRIPTION
## 新規登録画面の各種対応

### 新規登録画面
- 「既にアカウントをお持ちですか？」の「ログイン」画面へのリンク先に変更
- メールアドレスのバリデバリデーション対応
  - @の前に1文字以上の文字列
  - @後に1文字以上の文字列 かつ.が含まれること
- パスワードのバリデーション対応
  - 半角英字、数字、記号をすべて含むんでいない場合、バリデーション表示

### アカウント作成画面
- 誕生日 → 生年月日に変更
- 年月日の各種対応
  - 年 → 現在日付の年数から 1900年まで表示するように修正
  - 日
    - 年、月によって出す日付を修正
    - うるう年の場合、2月29日
    - 4,6,9,11月の場合 30日まで表示  

###  DB対応
- メールアドレスのカラムの長さを30 → 255に変更 
  