### PR TITLE
アカウント登録時、my_idがユニークで登録されるように修正

### DIFF
--- a/nextjs/app/api/v1/users/route.ts
+++ b/nextjs/app/api/v1/users/route.ts
@@ -3,6 +3,25 @@ import prisma from "@/prisma/client";
 
 export const runtime = "edge";
 
+function generateRandomId(): string {
+  const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  return Array.from({ length: 6 }, () => chars[Math.floor(Math.random() * chars.length)]).join("");
+}
+
+async function generateUniqueMyId(): Promise<string> {
+  while (true) {
+    const myId = generateRandomId();
+    const existingUser = await prisma.users.findUnique({
+      where: { my_id: myId },
+    });
+
+    if (!existingUser) {
+      const secondTryId = generateRandomId(); 
+      return secondTryId;
+    }
+  }
+}
+
 export async function POST(request: Request) {
   try {
     const { name, email, gender, profile_url, uid } = await request.json();
@@ -15,7 +34,7 @@ export async function POST(request: Request) {
         profile_url: profile_url,
         status: "active",
         birthday: new Date(),
-        my_id: "my_id",
+        my_id: await generateUniqueMyId(),
         show_sensitive_type: "default",
         uid: uid,
       },

--- a/nextjs/features/users/components/account-info-input.tsx
+++ b/nextjs/features/users/components/account-info-input.tsx
@@ -191,7 +191,7 @@ export const AccountInfoInput = ({
                         onChange={(e) => setDay(e.target.value)}
                       >
                         <option value="">日</option>
-                        {createDays(year, month).map((d) => (
+                        {createDays(Number(year), Number(month)).map((d) => (
                           <option key={d} value={d}>
                             {d}
                           </option>


### PR DESCRIPTION
### 概要
アカウント登録時、my_idのカラムがユニークであるにも関わらず、my_idを固定でinsertしていた
<img width="1460" alt="スクリーンショット 2025-03-09 16 30 35" src="https://github.com/user-attachments/assets/f3d3affc-5cab-4150-a222-15f467b99717" />


### 実装内容
- アカウント登録時、my_idがユニークで登録されるようにランダム英数字６文字を生成
- 生成されたmy_idが既にDBに登録済の場合、もう一度ランダムな文字列を生成し、存在しなければ登録
- アカウント登録画面でbuildエラー発生していたためついでに、修正