### PR TITLE
投稿フォームにおいてタグ追加時に、フォーム内をクリアする

### DIFF
--- a/nextjs/features/posts/components/post-form.tsx
+++ b/nextjs/features/posts/components/post-form.tsx
@@ -16,6 +16,7 @@ export const PostForm = ({ onClose }: { onClose: () => void }) => {
   const [errorBoothItems, setErrorBoothItems] = useState<string[]>([""]);
   const [errorTitle, setErrorTitle] = useState("");
   const [mainImage, setMainImage] = useState<ImageData | null>(null);
+  const [isCompositionStart, setIsCompositionStart] = useState<boolean>(false);
 
   const ageRestrictionOptions = [
     { label: "全年齢", isSensitive: false, value: "all" },
@@ -56,6 +57,10 @@ export const PostForm = ({ onClose }: { onClose: () => void }) => {
     setMainImage(images[index]);
   };
 
+  const handleCompositionStart = () => setIsCompositionStart(true);
+
+  const handleCompositionEnd = () => setIsCompositionStart(false);
+
   const handleTagInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTagInput(e.target.value);
   };
@@ -65,10 +70,14 @@ export const PostForm = ({ onClose }: { onClose: () => void }) => {
   };
 
   const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && tagInput.trim()) {
-      setTags([...tags, tagInput.trim()]);
-      setTagInput("");
+    if (e.key === "Enter" && !isCompositionStart) {
+      const tag = tagInput.trim();
       e.preventDefault();
+      // 同じタグが入力されたら、タグを追加しない
+      if (!tags.includes(tag)) {
+        setTags([...tags, tag]);
+      }
+      setTagInput("");
     }
   };
 
@@ -227,6 +236,8 @@ export const PostForm = ({ onClose }: { onClose: () => void }) => {
                       onKeyDown={handleTagInputKeyDown}
                       placeholder="タグを入力してEnterを押してください"
                       className={styles.postDetailTagInput}
+                      onCompositionStart={handleCompositionStart}
+                      onCompositionEnd={handleCompositionEnd}
                     />
                     <div className={styles.postDetailTagArea}>
                       {tags.map((tag, index) => (


### PR DESCRIPTION
### 概要
投稿フォームにおいてタグ追加時に、フォーム内に文字が残ってしまっているので、クリアして空白にする

### 対応内容
・タグをKeyDown時にフォーム内のタグ文字列を削除できるように修正
・日本語入力時、変換完了後に文字列を削除 & タグ追加できるように修正
・同じタグ名を複数設定できないようにタグが表示されていた場合、新たに追加できないようにした