### PR TITLE
タグ付きで投稿時、既にDBに保存されているタグをtagsmテーブルに登録しないようにする

### DIFF
--- a/nextjs/app/api/v1/posts/route.ts
+++ b/nextjs/app/api/v1/posts/route.ts
@@ -55,31 +55,61 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
     }
 
+    // 既に存在するタグを取得
+    const fetchRegisteredTags = await prisma.tags.findMany({
+      where: {
+        name: {
+          in: tags,
+        },
+      },
+    });
+
     const serializedImages = await uploadImages(images);
     const filteredTags = tags.filter((tag: string) => tag !== undefined && tag !== null);
 
-    await prisma.posts.create({
-      data: {
-        title: title,
-        description: description,
-        booth_items: {
-          create: formatBoothItems(boothItems),
+    await prisma.$transaction(async (tx) => {
+      const post = await tx.posts.create({
+        data: {
+          title: title,
+          description: description,
+          booth_items: {
+            create: formatBoothItems(boothItems),
+          },
+          images: {
+            create: serializedImages,
+          },
+          show_sensitive_type: show_sensitive_type,
+          user_id: user.id,
         },
-        images: {
-          create: serializedImages,
-        },
-        tags: {
-          create: filteredTags.map((tag: string) => ({
-            tag: {
-              create: {
+      });
+
+      const tagsToCreate = await Promise.all(
+        filteredTags.map(async (tag: string) => {
+          const existingTag = fetchRegisteredTags.find((t) => t.name === tag);
+          if (!existingTag) {
+            const newTag = await tx.tags.create({
+              data: {
                 name: tag,
               },
-            },
-          })),
-        },
-        show_sensitive_type: show_sensitive_type,
-        user_id: user.id,
-      },
+            });
+            return newTag;
+          }
+          return existingTag;
+        })
+      );
+
+      await Promise.all(
+        tagsToCreate.map(
+          async (tag: { id: string; name: string; created_at: Date; updated_at: Date }) => {
+            await tx.post_tags.create({
+              data: {
+                post_id: post.id,
+                tag_id: tag.id,
+              },
+            });
+          }
+        )
+      );
     });
 
     return NextResponse.json({ status: 200, message: "投稿に成功しました" });

--- a/nextjs/features/posts/components/post-form.tsx
+++ b/nextjs/features/posts/components/post-form.tsx
@@ -16,6 +16,7 @@ export const PostForm = ({ onClose }: { onClose: () => void }) => {
   const [errorBoothItems, setErrorBoothItems] = useState<string[]>([""]);
   const [errorTitle, setErrorTitle] = useState("");
   const [mainImage, setMainImage] = useState<ImageData | null>(null);
+  const [isCompositionStart, setIsCompositionStart] = useState<boolean>(false);
 
   const ageRestrictionOptions = [
     { label: "全年齢", isSensitive: false, value: "all" },
@@ -56,6 +57,10 @@ export const PostForm = ({ onClose }: { onClose: () => void }) => {
     setMainImage(images[index]);
   };
 
+  const handleCompositionStart = () => setIsCompositionStart(true);
+
+  const handleCompositionEnd = () => setIsCompositionStart(false);
+
   const handleTagInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTagInput(e.target.value);
   };
@@ -65,10 +70,14 @@ export const PostForm = ({ onClose }: { onClose: () => void }) => {
   };
 
   const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && tagInput.trim()) {
-      setTags([...tags, tagInput.trim()]);
-      setTagInput("");
+    if (e.key === "Enter" && !isCompositionStart) {
+      const tag = tagInput.trim();
       e.preventDefault();
+      // 同じタグが入力されたら、タグを追加しない
+      if (!tags.includes(tag)) {
+        setTags([...tags, tag]);
+      }
+      setTagInput("");
     }
   };
 
@@ -227,6 +236,8 @@ export const PostForm = ({ onClose }: { onClose: () => void }) => {
                       onKeyDown={handleTagInputKeyDown}
                       placeholder="タグを入力してEnterを押してください"
                       className={styles.postDetailTagInput}
+                      onCompositionStart={handleCompositionStart}
+                      onCompositionEnd={handleCompositionEnd}
                     />
                     <div className={styles.postDetailTagArea}>
                       {tags.map((tag, index) => (


### PR DESCRIPTION
### 概要
タグ付きで投稿時、既にDBに保存されているタグをtagsmテーブルに登録しないようにする

### 実装

- タグ付きで投稿時、投稿に紐づいているタグ名が既にtagsテーブルにあれば、tagsへ登録しない
- タグ付きで投稿時、投稿に紐づいているタグ名がtagsテーブルなければ、tagsへ登録する
- 画像投稿時、画像投稿とタグへの保存のINSERTを分けているため、トランザクションを制御を追加し、データの整合性を担保

