### PR TITLE
画像の投稿を３枚以上投稿すると、リクエストの容量制限(vercelの仕様)に引っかかる問題への対応

### DIFF
--- a/nextjs/app/api/v1/images/upload/route.ts
+++ b/nextjs/app/api/v1/images/upload/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { S3Service } from "@/app/api/services/s3-service";
+
+const uploadImage = async (image: {
+  file_data: string;
+  file_name: string;
+  width: number;
+  height: number;
+}) => {
+  const s3Service = new S3Service();
+  const url = await s3Service.uploadFileToS3(image.file_data, image.file_name);
+  return { url: url, width: image.width, height: image.height };
+};
+
+export async function POST(request: NextRequest) {
+  const { image } = await request.json();
+  const serializedImages = await uploadImage(image);
+
+  return NextResponse.json(serializedImages);
+}

--- a/nextjs/app/api/v1/posts/route.ts
+++ b/nextjs/app/api/v1/posts/route.ts
@@ -1,23 +1,8 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/libs/firebase/auth";
-import { S3Service } from "../../services/s3-service";
 import prisma from "@/prisma/client";
 
 export const runtime = "edge";
-
-const uploadImages = async (
-  images: { file_data: string; file_name: string; width: number; height: number }[]
-) => {
-  const s3Service = new S3Service();
-  return await Promise.all(
-    images.map(
-      async (image: { file_data: string; file_name: string; width: number; height: number }) => {
-        const url = await s3Service.uploadFileToS3(image.file_data, image.file_name);
-        return { url: url, width: image.width, height: image.height };
-      }
-    )
-  );
-};
 
 const formatBoothItems = (
   boothItems: { url: string; name: string; detail: string; image: string }[]
@@ -55,7 +40,6 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
     }
 
-    const serializedImages = await uploadImages(images);
     const filteredTags = tags.filter((tag: string) => tag !== undefined && tag !== null);
 
     await prisma.posts.create({
@@ -66,7 +50,7 @@ export async function POST(request: Request) {
           create: formatBoothItems(boothItems),
         },
         images: {
-          create: serializedImages,
+          create: images,
         },
         tags: {
           create: filteredTags.map((tag: string) => ({

--- a/nextjs/features/posts/components/post-form.tsx
+++ b/nextjs/features/posts/components/post-form.tsx
@@ -4,6 +4,7 @@ import { createPost } from "../endpoint";
 import styles from "../styles/post-form.module.scss";
 import { ImageData } from "../types";
 import { FaImage } from "react-icons/fa6";
+import { uploadImage } from "../endpoint";
 
 export const PostForm = ({ onClose }: { onClose: () => void }) => {
   const [images, setImages] = useState<ImageData[]>([]);
@@ -139,12 +140,19 @@ export const PostForm = ({ onClose }: { onClose: () => void }) => {
       return;
     }
 
+    const postImages = await Promise.all(
+      images.map(async (image) => {
+        const serializedImage = await uploadImage(image);
+        return serializedImage;
+      })
+    );
+
     try {
       await createPost({
         title,
         description,
         boothItems,
-        images,
+        images: postImages,
         tags,
         show_sensitive_type: selectedAgeRestriction,
       });

--- a/nextjs/features/posts/endpoint.ts
+++ b/nextjs/features/posts/endpoint.ts
@@ -60,7 +60,6 @@ export const createPost = async <T>(post: T) => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error
   const { boothItems, ...rest } = post;
-
   const boothItemsResponse = await Promise.all(
     boothItems.map(async (link: string) => {
       if (link.includes("https://")) {
@@ -93,6 +92,24 @@ export const addViewCountToPost = async (postId: string, headers?: Headers) => {
   if (!response.ok) {
     console.error(response);
     return "Failed to add view count to post";
+  }
+  const data = await response.json();
+  return data;
+};
+
+export const uploadImage = async (image: {
+  file_data: string;
+  file_name: string;
+  width: number;
+  height: number;
+}) => {
+  const response = await fetch(`${API_URL}/api/v1/images/upload`, {
+    method: "POST",
+    body: JSON.stringify({ image }),
+  });
+  if (!response.ok) {
+    console.error(response);
+    return "Failed to upload images";
   }
   const data = await response.json();
   return data;


### PR DESCRIPTION
### 概要
画像の投稿を３枚以上投稿すると、リクエストの容量制限(vercelの仕様)に引っかかるため、画像が複数枚投稿できなかった

### 実装内容

- 写真投稿時、DBへ登録前にs3アップロード用のAPIを経由して、先にs3へアップロードを行う
- s3アップロードされた情報を元に、post_imagesへデータ登録する用に修正