### PR TITLE
ユーザープロフィール画面のSNSリンクから各種SNSへのアイコンに遷移できるように修正

### DIFF
--- a/nextjs/features/users/components/user-home.tsx
+++ b/nextjs/features/users/components/user-home.tsx
@@ -18,7 +18,9 @@ const renderSocialLink = (socialLink: SocialLink) => {
     return (
       <div key={socialLink.platform_types} className={styles.profileIntroduceContent}>
         <FaXTwitter size={36} />
-        <p className={styles.profileIntroduceLink}>{socialLink.platform_url}</p>
+        <a href={socialLink.platform_url} className={styles.profileIntroduceLink}>
+          {socialLink.platform_url}
+        </a>
       </div>
     );
   }
@@ -27,7 +29,7 @@ const renderSocialLink = (socialLink: SocialLink) => {
     return (
       <div key={socialLink.platform_types} className={styles.profileIntroduceContent}>
         <FaDiscord size={36} />
-        <p className={styles.profileIntroduceLink}>{socialLink.platform_url}</p>
+        <a href={socialLink.platform_url} className={styles.profileIntroduceLink}>{socialLink.platform_url}</a>
       </div>
     );
   }
@@ -35,7 +37,7 @@ const renderSocialLink = (socialLink: SocialLink) => {
   return (
     <div key={socialLink.platform_types} className={styles.profileIntroduceContent}>
       <GrPersonalComputer size={36} />
-      <p className={styles.profileIntroduceLink}>{socialLink.platform_url}</p>
+      <a href={socialLink.platform_url} className={styles.profileIntroduceLink}>{socialLink.platform_url}</a>
     </div>
   );
 };


### PR DESCRIPTION
### 概要
ユーザープロフィール画面のSNSリンクから各種SNSへのアイコンに遷移できるように修正

https://github.com/user-attachments/assets/73266d00-507c-49fe-a593-1301d6a46fcb

