### PR TITLE
[パフォーマンス改善] データ遷移前に遷移先のデータ事前読み込み

### DIFF
--- a/nextjs/components/photo-gallerys/photo-cards/photo-card.tsx
+++ b/nextjs/components/photo-gallerys/photo-cards/photo-card.tsx
@@ -33,11 +33,13 @@ export const PhotoCard = ({
 
   const handleForwardToPostDetail = (postId: string | bigint) => {
     const postIdString = typeof postId === "bigint" ? postId.toString() : postId;
+    router.prefetch(`/posts/${postIdString}`);
     router.push(`/posts/${postIdString}`);
   };
 
   const handleForwardToUserDetail = (myId: string | bigint) => {
     const myIdString = typeof myId === "bigint" ? myId.toString() : myId;
+    router.prefetch(`/users/${myIdString}`);
     router.push(`/users/${myIdString}`);
   };
 

--- a/nextjs/components/post-card.tsx
+++ b/nextjs/components/post-card.tsx
@@ -42,11 +42,13 @@ export const PostCard = ({
 
   const handleForwardToPostDetail = (postId: string | bigint) => {
     const postIdString = typeof postId === "bigint" ? postId.toString() : postId;
+    router.prefetch(`/posts/${postIdString}`);
     router.push(`/posts/${postIdString}`);
   };
 
   const handleForwardToUserDetail = (myId: string | bigint) => {
     const myIdString = typeof myId === "bigint" ? myId.toString() : myId;
+    router.prefetch(`/users/${myIdString}`);
     router.push(`/users/${myIdString}`);
   };
 


### PR DESCRIPTION
### 概要
データ遷移時に遷移が遅い、そのため遷移前にデータ事前読み込みして、遷移体験を上げるようにした